### PR TITLE
Load less stylesheet asynchronously

### DIFF
--- a/workspace/utilities/master/css.xsl
+++ b/workspace/utilities/master/css.xsl
@@ -7,7 +7,7 @@
 		<xsl:choose>
 			<xsl:when test="$debug = true()">
 				<link rel="stylesheet/less" type="text/css" href="{$css-path}dev/{$less-file}.{$version}.less" />
-				<script>less = { env: 'development', useFileCache: false }; </script>
+				<script>less = { env: 'development', useFileCache: false, async: true }; </script>
 				<script src="https://cdnjs.cloudflare.com/ajax/libs/less.js/2.7.2/less.min.js"></script>
 				<xsl:if test="count(/data/params/url-watch) != 0">
 					<script>less.watchTimer = 3; less.watch();</script>


### PR DESCRIPTION
When less loads its stylesheet synchronously, it adds a "display: none "important" on the body which can make some of our code return erronous values because body is display none. Loading the stylesheets async fixes this problem.