### PR TITLE
Added query-string to data-respon-url attribute

### DIFF
--- a/workspace/utilities/master/master-body.xsl
+++ b/workspace/utilities/master/master-body.xsl
@@ -49,7 +49,15 @@
 		<xsl:variable name="computed-page-attr">
 			<add id="page-{$full-page-handle}" />
 			<add class="page" />
-			<add data-response-url="{$current-path}/" />
+			<set>
+				<xsl:attribute name="data-response-url">
+					<xsl:value-of select="concat(/data/params/current-path, '/')" />
+					<xsl:if test="string-length(/data/params/current-query-string) != 0">
+						<xsl:text>?</xsl:text>
+						<xsl:value-of select="/data/params/current-query-string" disable-output-escaping="yes" />
+					</xsl:if>
+				</xsl:attribute>
+			</set>
 			<xsl:call-template name="page-attr" />
 		</xsl:variable>
 	<!--																	/-->

--- a/workspace/utilities/master/master-body.xsl
+++ b/workspace/utilities/master/master-body.xsl
@@ -45,13 +45,6 @@
 			<add id="site-pages" />
 		</xsl:variable>
 		
-		<xsl:variable name="response-url">
-			<xsl:value-of select="concat(/data/params/current-path, '/')" />
-			<xsl:if test="string-length(/data/params/current-query-string) != 0">
-				<xsl:text>?</xsl:text>
-				<xsl:value-of select="/data/params/current-query-string" disable-output-escaping="yes" />
-			</xsl:if>
-		</xsl:variable>
 		<!-- page -->
 		<xsl:variable name="computed-page-attr">
 			<add id="page-{$full-page-handle}" />

--- a/workspace/utilities/master/master-body.xsl
+++ b/workspace/utilities/master/master-body.xsl
@@ -44,20 +44,19 @@
 		<xsl:variable name="computed-site-pages-attr">
 			<add id="site-pages" />
 		</xsl:variable>
-
+		
+		<xsl:variable name="response-url">
+			<xsl:value-of select="concat(/data/params/current-path, '/')" />
+			<xsl:if test="string-length(/data/params/current-query-string) != 0">
+				<xsl:text>?</xsl:text>
+				<xsl:value-of select="/data/params/current-query-string" disable-output-escaping="yes" />
+			</xsl:if>
+		</xsl:variable>
 		<!-- page -->
 		<xsl:variable name="computed-page-attr">
 			<add id="page-{$full-page-handle}" />
 			<add class="page" />
-			<set>
-				<xsl:attribute name="data-response-url">
-					<xsl:value-of select="concat(/data/params/current-path, '/')" />
-					<xsl:if test="string-length(/data/params/current-query-string) != 0">
-						<xsl:text>?</xsl:text>
-						<xsl:value-of select="/data/params/current-query-string" disable-output-escaping="yes" />
-					</xsl:if>
-				</xsl:attribute>
-			</set>
+			<set data-response-url="{$response-url}" />
 			<xsl:call-template name="page-attr" />
 		</xsl:variable>
 	<!--																	/-->

--- a/workspace/utilities/master/variables.xsl
+++ b/workspace/utilities/master/variables.xsl
@@ -37,6 +37,18 @@
 	count(/data/params/url-ndbg) = 0 and
 	(count(/data/params/use-dev) = 0 or /data/params/use-dev = 'yes')" />
 
+<!-- 
+	Response url :
+		Used by the framework to track server redirection
+-->
+<xsl:variable name="response-url">
+	<xsl:value-of select="concat(/data/params/current-path, '/')" />
+	<xsl:if test="string-length(/data/params/current-query-string) != 0">
+		<xsl:text>?</xsl:text>
+		<xsl:value-of select="/data/params/current-query-string" disable-output-escaping="yes" />
+	</xsl:if>
+</xsl:variable>
+
 <!-- Lang flag For multi langue -->
 <xsl:variable name="multi-langues">
 	<xsl:choose>


### PR DESCRIPTION
Without the query string in the attribute, the framework thinks there is a redirection and reloads the page. Adding the query string in the attribute fixes the problem.