### PR TITLE
Fixed the Mime type of the favicon ico

### DIFF
--- a/workspace/assets/css/lib/class-opacity.less
+++ b/workspace/assets/css/lib/class-opacity.less
@@ -1,7 +1,7 @@
 #generate-core-opacity-classes (@suffix: ~'') {
-	.opacity-0@{suffix}    {opacity: 0;}
+	.opacity-0@{suffix}, .transparent@{suffix}    {opacity: 0;}
 	.opacity-1_2@{suffix}  {opacity: 0.5;}
 	.opacity-1_4@{suffix}  {opacity: 0.25;}
 	.opacity-3_4@{suffix}  {opacity: 0.75;}
-	.opacity-full@{suffix} {opacity: 1;}
+	.opacity-full@{suffix}, .opaque@{suffix} {opacity: 1;}
 }

--- a/workspace/assets/css/lib/class-opacity.less
+++ b/workspace/assets/css/lib/class-opacity.less
@@ -1,7 +1,7 @@
 #generate-core-opacity-classes (@suffix: ~'') {
-	.opacity-0@{suffix}, .transparent@{suffix}    {opacity: 0;}
-	.opacity-1_2@{suffix}  {opacity: 0.5;}
-	.opacity-1_4@{suffix}  {opacity: 0.25;}
-	.opacity-3_4@{suffix}  {opacity: 0.75;}
-	.opacity-full@{suffix}, .opaque@{suffix} {opacity: 1;}
+	.opacity-0@{suffix}, .transparent@{suffix} {opacity: 0;}
+	.opacity-1_2@{suffix}                      {opacity: 0.5;}
+	.opacity-1_4@{suffix}                      {opacity: 0.25;}
+	.opacity-3_4@{suffix}                      {opacity: 0.75;}
+	.opacity-full@{suffix}, .opaque@{suffix}   {opacity: 1;}
 }

--- a/workspace/utilities/master/favicon.xsl
+++ b/workspace/utilities/master/favicon.xsl
@@ -11,7 +11,7 @@
 		</xsl:variable>
 
 		<link rel="shortcut icon"     href="{$root}/{$filename}.ico" type="image/vnd.microsoft.icon" />
-		<link rel="icon"              href="{$root}/{$filename}.ico" type="image/ico" />
+		<link rel="icon"              href="{$root}/{$filename}.ico" type="image/x-icon" />
 		<link rel="icon"              href="{$root}/{$filename}.png" type="image/png" />
 		<link rel="apple-touch-icon"  href="{$root}/{$filename}.png" type="image/png" />
 		<link rel="pavatar"           href="{$root}/{$filename}.png" type="image/png" />


### PR DESCRIPTION
> Other kinds of images can be found in Web documents. For example, many browsers support icon image types for favicons or similar. In particular, ICO images are supported in this context with the image/x-icon MIME type.
[Source](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)
💃🏻