### PR TITLE
Fix selector precision to reflect the real problem on IE

### DIFF
--- a/workspace/assets/css/dev/watchdog.less
+++ b/workspace/assets/css/dev/watchdog.less
@@ -46,7 +46,7 @@ a:not(.block):not(.inline-block) > img[data-src-format] {
 	.WATCHDOG(~'IMG MAY NOT BE JIT CORRECTLY WITH A LINK NOT BLOCK OR INLINE-BLOCK AS CONTAINER.');
 }
 
-.flexbox.flex-center.margin-horizontal-auto {
+.flexbox.flex-center > .margin-horizontal-auto {
 	.WATCHDOG(~'flexbox + flex-center + margin-horizontal-auto NOT WORKING ON IE 11.');
 }
 

--- a/workspace/assets/css/dev/watchdog.less
+++ b/workspace/assets/css/dev/watchdog.less
@@ -47,7 +47,7 @@ a:not(.block):not(.inline-block) > img[data-src-format] {
 }
 
 .flexbox.flex-center > .margin-horizontal-auto {
-	.WATCHDOG(~'flexbox + flex-center + margin-horizontal-auto NOT WORKING ON IE 11.');
+	.WATCHDOG(~'flexbox + flex-center > margin-horizontal-auto NOT WORKING ON IE 11.');
 }
 
 .full-width {


### PR DESCRIPTION
The bug appears when an element with margin auto is **a child** of another element with .flexbox and .flex-center.