### PR TITLE
Reset Font Feature Default

### DIFF
--- a/workspace/assets/css/lib/_root-site.less
+++ b/workspace/assets/css/lib/_root-site.less
@@ -26,7 +26,6 @@ html {
 }
 
 body {
-	-webkit-font-feature-settings: "hist";
 	min-height: 100%;
 	overflow-y: scroll;
 	overflow-x: hidden;


### PR DESCRIPTION
This css line was changing the default value (normal) and causing some mind boggling bug on Chrome only. Better to keep default and change it per project, if necessary.