### PR TITLE
Add proper uri encoding for share links

### DIFF
--- a/workspace/utilities/lib/share-link.xsl
+++ b/workspace/utilities/lib/share-link.xsl
@@ -41,7 +41,7 @@
 		<xsl:variable name="computed-url">
 			<xsl:choose>
 				<xsl:when test="string-length($status) != 0">
-					<xsl:value-of select="concat('?subject=', $encoded-status, ' | NATIONAL',  '&amp;body=', $encoded-body)" />
+					<xsl:value-of select="concat('?subject=', $encoded-status, $separator,  '&amp;body=', $encoded-body)" />
 				</xsl:when>
 				<xsl:otherwise>
 					<xsl:value-of select="concat('?body=', $encoded-body)" />

--- a/workspace/utilities/lib/share-link.xsl
+++ b/workspace/utilities/lib/share-link.xsl
@@ -35,13 +35,16 @@
 		<xsl:param name="separator" select="' - '" />
 		<xsl:param name="url" />
 
+		<xsl:variable name="encoded-status" select="str:encode-uri($status, true())" />
+		<xsl:variable name="encoded-body" select="str:encode-uri($url, true())" />
+
 		<xsl:variable name="computed-url">
 			<xsl:choose>
 				<xsl:when test="string-length($status) != 0">
-					<xsl:value-of select="str:encode-uri(concat('?subject=', $status, '&amp;body=', $url), false())" />
+					<xsl:value-of select="concat('?subject=', $encoded-status, ' | NATIONAL',  '&amp;body=', $encoded-body)" />
 				</xsl:when>
 				<xsl:otherwise>
-					<xsl:value-of select="str:encode-uri(concat('?body=', $url), false())" />
+					<xsl:value-of select="concat('?body=', $encoded-body)" />
 				</xsl:otherwise>
 			</xsl:choose>
 		</xsl:variable>
@@ -80,7 +83,7 @@
 
 		<xsl:call-template name="share-link">
 			<xsl:with-param name="attr" select="$attr" />
-			<xsl:with-param name="url" select="concat('https://twitter.com/home?status=', $computed-status)" />
+			<xsl:with-param name="url" select="concat('https://twitter.com/home?status=', str:encode-uri($computed-status, true()))" />
 			<xsl:with-param name="content" select="$content"/>
 		</xsl:call-template>
 	</xsl:template>
@@ -92,7 +95,7 @@
 
 		<xsl:call-template name="share-link">
 			<xsl:with-param name="attr" select="$attr" />
-			<xsl:with-param name="url" select="concat('https://www.facebook.com/sharer/sharer.php?u=', $url)" />
+			<xsl:with-param name="url" select="concat('https://www.facebook.com/sharer/sharer.php?u=', str:encode-uri($url, true()))" />
 			<xsl:with-param name="content" select="$content"/>
 		</xsl:call-template>
 	</xsl:template>
@@ -105,7 +108,7 @@
 
 		<xsl:call-template name="share-link">
 			<xsl:with-param name="attr" select="$attr" />
-			<xsl:with-param name="url" select="concat('https://www.linkedin.com/shareArticle?mini=true&amp;url=', $url, '&amp;title=', $status)" />
+			<xsl:with-param name="url" select="concat('https://www.linkedin.com/shareArticle?mini=true&amp;url=', str:encode-uri($url, true()), '&amp;title=', str:encode-uri($status, true()))" />
 			<xsl:with-param name="content" select="$content"/>
 		</xsl:call-template>
 	</xsl:template>

--- a/workspace/utilities/lib/share-link.xsl
+++ b/workspace/utilities/lib/share-link.xsl
@@ -32,7 +32,6 @@
 		<xsl:param name="attr" />
 		<xsl:param name="content" />
 		<xsl:param name="status" />
-		<xsl:param name="separator" select="' - '" />
 		<xsl:param name="url" />
 
 		<xsl:variable name="encoded-status" select="str:encode-uri($status, true())" />

--- a/workspace/utilities/lib/share-link.xsl
+++ b/workspace/utilities/lib/share-link.xsl
@@ -41,7 +41,7 @@
 		<xsl:variable name="computed-url">
 			<xsl:choose>
 				<xsl:when test="string-length($status) != 0">
-					<xsl:value-of select="concat('?subject=', $encoded-status, $separator,  '&amp;body=', $encoded-body)" />
+					<xsl:value-of select="concat('?subject=', $encoded-status, '&amp;body=', $encoded-body)" />
 				</xsl:when>
 				<xsl:otherwise>
 					<xsl:value-of select="concat('?body=', $encoded-body)" />


### PR DESCRIPTION
The query-strings in the share links are either not encoded properly or not encoded at all. Proper encoding has been added to each share-link