### PR TITLE
Add missing comma for default english date format

### DIFF
--- a/workspace/utilities/site-variables.xsl
+++ b/workspace/utilities/site-variables.xsl
@@ -16,7 +16,7 @@
 <!-- DATES -->
 <xsl:variable name="date-format">
 	<xsl:choose>
-		<xsl:when test="$url-language = 'en'">M D Y</xsl:when>
+		<xsl:when test="$url-language = 'en'">M D, Y</xsl:when>
 		<xsl:otherwise>d M Y</xsl:otherwise>
 	</xsl:choose>
 </xsl:variable>


### PR DESCRIPTION
The default english date format, which is the american one because the month is before the day, should always have a comma separating the year from the rest.