### PR TITLE
Normalize use of none vs 0 in margin and padding

### DIFF
--- a/workspace/assets/css/lib/_deprecated.less
+++ b/workspace/assets/css/lib/_deprecated.less
@@ -25,3 +25,20 @@
 .transform-origin-top-left      {#transform-origin(top left);             .DEPRECATED(~'Use transform-origin-left-top');}
 .transform-origin-top-right     {#transform-origin(top right);            .DEPRECATED(~'Use transform-origin-right-top');}
 .transform-origin-center-center {#transform-origin(center center);        .DEPRECATED(~'Use transform-origin-center');}
+[class*="margin-none"],
+[class*="margin-horizontal-none"],
+[class*="margin-vertical-none"],
+[class*="margin-top-none"],
+[class*="margin-bottom-none"],
+[class*="margin-left-none"],
+[class*="margin-right-none"],
+[class*="padding-none"],
+[class*="padding-horizontal-none"],
+[class*="padding-vertical-none"],
+[class*="padding-top-none"],
+[class*="padding-bottom-none"],
+[class*="padding-left-none"],
+[class*="padding-right-none"] {
+	.DEPRECATED(~'Use padding/margin 0 instead of none');
+}
+

--- a/workspace/assets/css/lib/class-margin.less
+++ b/workspace/assets/css/lib/class-margin.less
@@ -10,7 +10,6 @@
 #generate-core-margin-classes (@direction: ~'', @suffix: ~'') {
 	#generate-margin-classes-value(@direction, @suffix, ~'0',         ~'0');
 	#generate-margin-classes-value(@direction, @suffix, ~'0-important',         ~'0!important');
-	#generate-margin-classes-value(@direction, @suffix, ~'none',      ~'0');
 	#generate-margin-classes-value(@direction, @suffix, ~'auto',      ~'auto');
 	// PX
 	#generate-margin-classes-value(@direction, @suffix, ~'1px',       ~'1px');
@@ -56,7 +55,7 @@
 }
 #generate-core-margin-two-axes-classes(@direction, @axe1, @axe2, @suffix: ~'') {
 	#generate-margin-two-axes-class-value(@direction, @suffix, @axe1, @axe2, ~'0', ~'0');
-	#generate-margin-two-axes-class-value(@direction, @suffix, @axe1, @axe2, ~'none', ~'0');
+	#generate-margin-two-axes-class-value(@direction, @suffix, @axe1, @axe2, ~'0-important', ~'0!important');
 	#generate-margin-two-axes-class-value(@direction, @suffix, @axe1, @axe2, ~'auto', ~'auto');
 	// PX
 	#generate-margin-two-axes-class-value(@direction, @suffix, @axe1, @axe2, ~'1px', ~'1px');

--- a/workspace/assets/css/lib/class-padding.less
+++ b/workspace/assets/css/lib/class-padding.less
@@ -9,8 +9,7 @@
 }
 #generate-core-padding-classes (@direction: ~'', @suffix: ~'') {
 	#generate-padding-classes-value(@direction, @suffix, ~'0', 0);
-	#generate-padding-classes-value(@direction, @suffix, ~'none', 0);
-	#generate-padding-classes-value(@direction, @suffix, ~'none-important', ~'0 !important');
+	#generate-padding-classes-value(@direction, @suffix, ~'0-important',         ~'0!important');
 	// RATIONNAL
 	#generate-padding-classes-value(@direction, @suffix, ~'1_2',   50%);
 	#generate-padding-classes-value(@direction, @suffix, ~'1_3',  100% / 3);
@@ -49,8 +48,7 @@
 }
 #generate-core-padding-two-axes-classes(@direction, @axe1, @axe2, @suffix: ~'') {
 	#generate-padding-two-axes-class-value(@direction, @suffix, @axe1, @axe2, ~'0', 0);
-	#generate-padding-two-axes-class-value(@direction, @suffix, @axe1, @axe2, ~'none', 0);
-	#generate-padding-two-axes-class-value(@direction, @suffix, @axe1, @axe2, ~'none-important', ~'0 !important');
+	#generate-padding-two-axes-class-value(@direction, @suffix, @axe1, @axe2, ~'0-important', ~'0 !important');
 	#generate-padding-two-axes-class-value(@direction, @suffix, @axe1, @axe2, ~'auto', auto);
 	// RATIONNAL
 	#generate-padding-two-axes-class-value(@direction, @suffix, @axe1, @axe2, ~'1_2',   50%);


### PR DESCRIPTION
Was sick of having _none-important_ for paddings and _0-important_ for margins. Following a discussion with @alexnantel88, we agreed on the use of "0" instead of "none" and therefore remove "none" from those files.