### PR TITLE
Avoid conflict with the escape key and general popup

### DIFF
--- a/workspace/assets/js/dev/panel.js
+++ b/workspace/assets/js/dev/panel.js
@@ -163,8 +163,6 @@
 
 		$(document).on('keydown', function (e) {
 			if (e.which === global.keys.escape && attached) {
-				var attFx = attached ? 'detach' : 'appendTo';
-				panel[attFx](attached ? undefined : body);
 				panel.detach();
 				attached = false;
 			} else if (e.which === global.keys.pause_break && e.shiftKey) {

--- a/workspace/assets/js/dev/panel.js
+++ b/workspace/assets/js/dev/panel.js
@@ -158,10 +158,15 @@
 		_.each(checkboxes, function (c) {
 			inner.append(c);
 		});
+
 		var attached = false;
 
 		$(document).on('keydown', function (e) {
-			if (e.which === global.keys.escape) {
+			if (e.which === global.keys.escape && attached) {
+				var attFx = attached ? 'detach' : 'appendTo';
+				panel[attFx](attached ? undefined : body);
+				attached = !attached;
+			} else if (e.which === global.keys.pause_break && e.shiftKey) {
 				var attFx = attached ? 'detach' : 'appendTo';
 				panel[attFx](attached ? undefined : body);
 				attached = !attached;

--- a/workspace/assets/js/dev/panel.js
+++ b/workspace/assets/js/dev/panel.js
@@ -165,7 +165,8 @@
 			if (e.which === global.keys.escape && attached) {
 				var attFx = attached ? 'detach' : 'appendTo';
 				panel[attFx](attached ? undefined : body);
-				attached = !attached;
+				panel.detach();
+				attached = false;
 			} else if (e.which === global.keys.pause_break && e.shiftKey) {
 				var attFx = attached ? 'detach' : 'appendTo';
 				panel[attFx](attached ? undefined : body);


### PR DESCRIPTION
Change the open trigger of the dev panel to be shift + Pause/Break and keep escape also to close it. Dont use escape key to open de panel.