### PR TITLE
Add site credits component

### DIFF
--- a/workspace/utilities/com/site-credits.xsl
+++ b/workspace/utilities/com/site-credits.xsl
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<!-- COMPONENT: site-credits -->
+	<xsl:template name="site-credits">
+		<xsl:param name="text">
+			<xsl:choose>
+				<xsl:when test="$url-language = 'fr'">
+					<xsl:text>Crédits</xsl:text>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:text>Credits</xsl:text>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:param>
+		<xsl:param name="ext-attr" />
+
+
+		<!-- ATTRIBUTES -->
+		<xsl:variable name="attr">
+			<add class="flex-shrink-0 overflow-hidden" />
+			<add class="relative cursor-pointer" />
+			<add class="transition-site-credits" />
+			<xsl:copy-of select="$ext-attr"/>
+			<add dev-component="site-credits" />
+		</xsl:variable>
+
+		<xsl:variable name="attr-text">
+			<add class="absolute fill z-index-1" />
+			<add class="flexbox align-items-center justify-content-center" />
+			<add class="transition-text" />
+			<add dev-element="text" />
+		</xsl:variable>
+
+		<xsl:variable name="attr-logo">
+			<add class="relative z-index-4" />
+			<add class="transition-logo" />
+			<add dev-element="logo" />
+		</xsl:variable>
+
+
+		<!-- STRUCTURE -->
+		<xsl:call-template name="element">
+			<xsl:with-param name="attr" select="$attr" />
+			<xsl:with-param name="content">
+				<!-- Text -->
+				<xsl:call-template name="element">
+					<xsl:with-param name="attr" select="$attr-text" />
+					<xsl:with-param name="element" select="'span'" />
+					<xsl:with-param name="content" select="$text" />
+				</xsl:call-template>
+				<!-- Logo -->
+				<xsl:call-template name="element">
+					<xsl:with-param name="attr" select="$attr-logo" />
+					<xsl:with-param name="content">
+						<!-- COMP: iframe-copyright-288 -->
+						<xsl:call-template name="iframe-copyright-288">
+							<xsl:with-param name="word" select="''" />
+							<xsl:with-param name="logo-always-animated" select="'true'" />
+							<xsl:with-param name="display" select="'block'" />
+							<xsl:with-param name="w" select="'117,97'" />
+							<xsl:with-param name="h" select="'24'" />
+						</xsl:call-template>
+					</xsl:with-param>
+				</xsl:call-template>
+			</xsl:with-param> 
+		</xsl:call-template>
+	</xsl:template>
+</xsl:stylesheet>

--- a/workspace/utilities/com/site-credits.xsl
+++ b/workspace/utilities/com/site-credits.xsl
@@ -55,8 +55,6 @@
 							<xsl:with-param name="word" select="''" />
 							<xsl:with-param name="logo-always-animated" select="'true'" />
 							<xsl:with-param name="display" select="'block'" />
-							<xsl:with-param name="w" select="'117,97'" />
-							<xsl:with-param name="h" select="'24'" />
 						</xsl:call-template>
 					</xsl:with-param>
 				</xsl:call-template>

--- a/workspace/utilities/com/site-credits.xsl
+++ b/workspace/utilities/com/site-credits.xsl
@@ -20,7 +20,6 @@
 		<xsl:variable name="attr">
 			<add class="flex-shrink-0 overflow-hidden" />
 			<add class="relative cursor-pointer" />
-			<add class="transition-site-credits" />
 			<xsl:copy-of select="$ext-attr"/>
 			<add dev-component="site-credits" />
 		</xsl:variable>
@@ -28,13 +27,11 @@
 		<xsl:variable name="attr-text">
 			<add class="absolute fill z-index-1" />
 			<add class="flexbox align-items-center justify-content-center" />
-			<add class="transition-text" />
 			<add dev-element="text" />
 		</xsl:variable>
 
 		<xsl:variable name="attr-logo">
 			<add class="relative z-index-4" />
-			<add class="transition-logo" />
 			<add dev-element="logo" />
 		</xsl:variable>
 


### PR DESCRIPTION
The text in our credits iframe sucks. It's not responsive, its almost never in the same style as the rest of the site and it can't be modified from outside the iframe. This new component simply takes the iframe, shows ONLY the logo. It then adds the text over the iframe. It allows to then transition these 2 elements however we'd like and also allows to style text and add responsive rules and everything we can do to normal elements.