### PR TITLE
Fix twitter share link

### DIFF
--- a/workspace/utilities/lib/share-link.xsl
+++ b/workspace/utilities/lib/share-link.xsl
@@ -82,7 +82,7 @@
 
 		<xsl:call-template name="share-link">
 			<xsl:with-param name="attr" select="$attr" />
-			<xsl:with-param name="url" select="concat('https://twitter.com/home?status=', str:encode-uri($computed-status, true()))" />
+			<xsl:with-param name="url" select="concat('https://twitter.com/intent/tweet?text=', str:encode-uri($computed-status, true()))" />
 			<xsl:with-param name="content" select="$content"/>
 		</xsl:call-template>
 	</xsl:template>


### PR DESCRIPTION
The twitter client on iOS stopped reconizing the home url and requires
the intent one.