### PR TITLE
Add framework generated classes to whitelist

### DIFF
--- a/workspace/assets/tasks/cssopruner.js
+++ b/workspace/assets/tasks/cssopruner.js
@@ -30,7 +30,21 @@ module.exports = function cssopruner (grunt) {
 						'br',
 						'active',
 						'hr',
-						/^ui/
+						/^ui/,
+						'chrome',
+						'firefox',
+						'safari',
+						'internetexplorer',
+						'edge',
+						'iphone',
+						'ipad',
+						'ios',
+						'mobile',
+						'android',
+						'phone',
+						'tablet',
+						'touch',
+						'click'
 					],
 					blacklist: ['www', 'version', 'xml']
 				}


### PR DESCRIPTION
This makes the pruner keep those classes even if they are not in the
code source. framework.js adds them for us.