### PR TITLE
Add use case for type number

### DIFF
--- a/workspace/utilities/lib/content.xsl
+++ b/workspace/utilities/lib/content.xsl
@@ -8,7 +8,7 @@
 		<xsl:param name="lg" select="$url-language"/>
 		
 		<xsl:choose>
-			<xsl:when test="exslt:object-type($content) = 'string'">
+			<xsl:when test="exslt:object-type($content) = 'string' or exslt:object-type($content) = 'number'">
 				<xsl:value-of select="$content" />
 			</xsl:when>
 			<xsl:when test="exslt:object-type($content) = 'RTF'">


### PR DESCRIPTION
Previously, type number would go to the otherwise which make xslt crash because the "/*". When type = number, we want a simple value-of.