### PR TITLE
Picture template to replace render-image

### DIFF
--- a/workspace/utilities/lib/picture.xsl
+++ b/workspace/utilities/lib/picture.xsl
@@ -5,14 +5,14 @@
 
 	<xsl:variable name="default-image-sizes">
 		<sizes>
-			<size height="0" width="430" media="(max-width: 430px)" />
-			<size height="0" width="620" media="(max-width: 620px)" />
-			<size height="0" width="800" media="(max-width: 800px)" />
-			<size height="0" width="960" media="(max-width: 960px)" />
-			<size height="0" width="1100" media="(max-width: 1100px)" />
-			<size height="0" width="1260" media="(max-width: 1260px)" />
-			<size height="0" width="1400" media="(max-width: 1400px)" />
-			<size height="0" width="2000" media="(max-width: 2000px)" />
+			<size request-height="0" request-width="430" media="(max-width: 430px)" />
+			<size request-height="0" request-width="620" media="(max-width: 620px)" />
+			<size request-height="0" request-width="800" media="(max-width: 800px)" />
+			<size request-height="0" request-width="960" media="(max-width: 960px)" />
+			<size request-height="0" request-width="1100" media="(max-width: 1100px)" />
+			<size request-height="0" request-width="1260" media="(max-width: 1260px)" />
+			<size request-height="0" request-width="1400" media="(max-width: 1400px)" />
+			<size request-height="0" request-width="2000" media="(max-width: 2000px)" />
 		</sizes>
 	</xsl:variable>
 
@@ -84,9 +84,9 @@
 		<xsl:param name="image" />
 		<xsl:param name="size" />
 		<xsl:text>/image/1/</xsl:text>
-		<xsl:value-of select="$size/@height" />
+		<xsl:value-of select="$size/@request-height" />
 		<xsl:text>/</xsl:text>
-		<xsl:value-of select="$size/@width" />
+		<xsl:value-of select="$size/@request-width" />
 		<xsl:value-of select="$image/@path" />
 		<xsl:text>/</xsl:text>
 		<xsl:value-of select="$image/filename" />

--- a/workspace/utilities/lib/picture.xsl
+++ b/workspace/utilities/lib/picture.xsl
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+								xmlns:exsl="http://exslt.org/common" 
+								extension-element-prefixes="exsl">
+
+	<xsl:variable name="default-image-sizes">
+		<sizes>
+			<size height="0" width="430" media="(max-width: 430px)" />
+			<size height="0" width="620" media="(max-width: 620px)" />
+			<size height="0" width="800" media="(max-width: 800px)" />
+			<size height="0" width="960" media="(max-width: 960px)" />
+			<size height="0" width="1100" media="(max-width: 1100px)" />
+			<size height="0" width="1260" media="(max-width: 1260px)" />
+			<size height="0" width="1400" media="(max-width: 1400px)" />
+			<size height="0" width="2000" media="(max-width: 2000px)" />
+		</sizes>
+	</xsl:variable>
+
+	<xsl:template name="picture">
+		<xsl:param name="image" select="image" />
+		<xsl:param name="alt" select="alt" />
+		<xsl:param name="sizes" select="exsl:node-set($default-image-sizes)/sizes" />
+		<xsl:param name="use-sizes" select="$image/@type != 'image/gif' and $image/@type != 'image/svg+xml'"/>
+		<xsl:param name="ext-attr" />
+		<xsl:param name="ext-attr-image" />
+
+		<xsl:variable name="attr">
+			<xsl:copy-of select="$ext-attr" />
+			<add dev-component="picture" />
+		</xsl:variable>
+
+		<xsl:variable name="attr-img">
+			<add class="block width-full" />
+			<set src="/workspace{$image/@path}/{$image/filename}" />
+			<set alt="{$alt}" />
+			<set loading="lazy" />
+			<xsl:copy-of select="$ext-attr-image" />
+			<add dev-element="img" />
+		</xsl:variable>
+
+		<xsl:call-template name="element">
+			<xsl:with-param name="attr" select="$attr" />
+			<xsl:with-param name="element" select="'picture'" />
+			<xsl:with-param name="content">
+
+				<xsl:if test="$use-sizes">
+					<xsl:apply-templates select="$sizes/size" mode="picture-source">
+						<xsl:with-param name="image" select="$image" />
+					</xsl:apply-templates>
+				</xsl:if>
+
+				<xsl:call-template name="element">
+					<xsl:with-param name="attr" select="$attr-img" />
+					<xsl:with-param name="element" select="'img'" />
+				</xsl:call-template>
+			</xsl:with-param>
+		</xsl:call-template>
+	</xsl:template>
+
+	<xsl:template match="size" mode="picture-source">
+		<xsl:param name="size" select="." />
+		<xsl:param name="image" />
+		<xsl:param name="srcset">
+			<xsl:call-template name="picture-src">
+				<xsl:with-param name="size" select="$size" />
+				<xsl:with-param name="image" select="$image" />
+			</xsl:call-template>
+		</xsl:param>
+
+		<xsl:variable name="attr">
+			<set srcset="{$srcset}" />
+			<!-- <set type="{$image/@type}" /> seems to be laggy with svg uploads application/octetstream stuff -->
+			<set media="{$size/@media}" />
+			<add dev-element="picture-source" />
+		</xsl:variable>
+
+		<xsl:call-template name="element">
+			<xsl:with-param name="attr" select="$attr" />
+			<xsl:with-param name="element" select="'source'" />
+		</xsl:call-template>
+	</xsl:template> <!-- picture-source -->
+
+	<xsl:template name="picture-src">
+		<xsl:param name="image" />
+		<xsl:param name="size" />
+		<xsl:text>/image/1/</xsl:text>
+		<xsl:value-of select="$size/@height" />
+		<xsl:text>/</xsl:text>
+		<xsl:value-of select="$size/@width" />
+		<xsl:value-of select="$image/@path" />
+		<xsl:text>/</xsl:text>
+		<xsl:value-of select="$image/filename" />
+	</xsl:template> <!-- picture-src -->
+
+</xsl:stylesheet>

--- a/workspace/utilities/master/master.xsl
+++ b/workspace/utilities/master/master.xsl
@@ -44,6 +44,7 @@
 
 	<!-- images -->
 	<xsl:import href="../lib/render-image.xsl" />
+	<xsl:import href="../lib/picture.xsl" />
 	
 	<!-- LIB SVG -->
 	<xsl:import href="../lib/svg-socials-icons.xsl" />


### PR DESCRIPTION
Holla 👋 

This p-r introduce a new template used for images in our websites.

This template would only render a simple picture tag with preselected sizes for the responsive layouts.

The css background-images would be rendered by this template using css properties like `object-fit` and `object-position`.

The philosophy on it should be that every template is overridable by non-lib files (ex: override the picture-src template to implement a image CDN) and every picture could have it's own set of custom sizes.

WDYT ?