### PR TITLE
(fix) Add f288-models- detection to add 2 pages models

### DIFF
--- a/workspace/utilities/lib/fx-url-creator.xsl
+++ b/workspace/utilities/lib/fx-url-creator.xsl
@@ -4,62 +4,120 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	exclude-result-prefixes="exsl">
 
-<xsl:variable name="allowArgsName" select="'f288-allowArgs'" />
+	<xsl:variable name="allowArgsName" select="'f288-allowArgs'" />
 
-<xsl:template name="framework-288-url-creator">
-	<xsl:apply-templates select="/data/pages" mode="framework-288-url-creator" />
-</xsl:template>
+	<xsl:template name="framework-288-url-creator">
+		<xsl:apply-templates select="/data/pages" mode="framework-288-url-creator" />
+	</xsl:template>
 
-<xsl:template match="data/pages" mode="framework-288-url-creator">
-	<script>
-		<!-- All pages except index -->
-		<xsl:for-each select="page">
-			<xsl:if test="count(./types/type [. = 'index']) = 0">
-				<xsl:apply-templates select="." mode="framework-288-url-creator"/>
-			</xsl:if>
-		</xsl:for-each>
+	<xsl:template match="data/pages" mode="framework-288-url-creator">
+		<script>
+			<!-- All pages except index -->
+			<xsl:for-each select="page">
+				<xsl:if test="count(./types/type [. = 'index']) = 0">
+					<xsl:apply-templates select="." mode="framework-288-url-creator"/>
+				</xsl:if>
+			</xsl:for-each>
+			
+			<!-- Special case if current page is 403 or 404 -->
+			<xsl:choose>
+				<xsl:when test="count(/data/params/page-types/item[@handle='404']) != 0">
+					<xsl:call-template name="framework-288-render-page">
+						<xsl:with-param name="handle" select="'404'" />
+						<xsl:with-param name="model">
+							<xsl:call-template name="framework-288-page-model">
+								<xsl:with-param name="types" select="/data/params/page-types/item" />
+							</xsl:call-template>
+						</xsl:with-param>
+					</xsl:call-template>
+				</xsl:when>
+				<xsl:when test="count(/data/params/page-types/item[@handle='403']) != 0">
+					<xsl:call-template name="framework-288-render-page">
+						<xsl:with-param name="handle" select="'403'" />
+						<xsl:with-param name="model">
+							<xsl:call-template name="framework-288-page-model">
+								<xsl:with-param name="types" select="/data/params/page-types/item" />
+							</xsl:call-template>
+						</xsl:with-param>
+					</xsl:call-template>
+				</xsl:when>
+			</xsl:choose>
+			
+			<!-- Index page -->
+			<xsl:apply-templates select="page[./types/type = 'index']" mode="framework-288-url-creator" />
+		</script>
+	</xsl:template>
+
+	<xsl:template match="page" mode="framework-288-url-creator">
+		<xsl:if test="count(page) &gt; 0">
+			<xsl:apply-templates select="page" mode="framework-288-url-creator" />
+		</xsl:if>
 		
-		<!-- Special case if current page is 403 or 404 -->
-		<xsl:choose>
-			<xsl:when test="count(/data/params/page-types/item[@handle='404']) != 0">
-				<xsl:call-template name="framework-288-render-page">
-					<xsl:with-param name="handle" select="'404'" />
-					<xsl:with-param name="model">
-						<xsl:call-template name="framework-288-page-model">
-							<xsl:with-param name="types" select="/data/params/page-types/item" />
-						</xsl:call-template>
-					</xsl:with-param>
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:when test="count(/data/params/page-types/item[@handle='403']) != 0">
-				<xsl:call-template name="framework-288-render-page">
-					<xsl:with-param name="handle" select="'403'" />
-					<xsl:with-param name="model">
-						<xsl:call-template name="framework-288-page-model">
-							<xsl:with-param name="types" select="/data/params/page-types/item" />
-						</xsl:call-template>
-					</xsl:with-param>
-				</xsl:call-template>
-			</xsl:when>
-		</xsl:choose>
+		<xsl:variable name="item" select="." />
 		
-		<!-- Index page -->
-		<xsl:apply-templates select="page[./types/type = 'index']" mode="framework-288-url-creator" />
-	</script>
-</xsl:template>
+		<xsl:variable name="handle">
+			<xsl:apply-templates select="." mode="full-page-handle-creator" />
+		</xsl:variable>
+		
+		<xsl:variable name="routes">
+			<xsl:call-template name="framework-288-page-routes">
+				<xsl:with-param name="item" select="$item" />
+			</xsl:call-template>
+		</xsl:variable>
+		
+		<xsl:variable name="model">
+			<xsl:call-template name="framework-288-page-model">
+				<xsl:with-param name="types" select="types/type" />
+			</xsl:call-template>
+		</xsl:variable>
+		
+		<xsl:if test="count(types/type[. = 'f288-hidden']) = 0 and count(types/type[. = 'hidden']) = 0 and (count(types/type[. = 'admin']) = 0 or $is-logged-in = true())">
 
-<xsl:template match="page" mode="framework-288-url-creator">
-	<xsl:if test="count(page) &gt; 0">
-		<xsl:apply-templates select="page" mode="framework-288-url-creator" />
-	</xsl:if>
-	
-	<xsl:variable name="item" select="." />
-	
-	<xsl:variable name="handle">
-		<xsl:apply-templates select="." mode="full-page-handle-creator" />
-	</xsl:variable>
-	
-	<xsl:variable name="routes">
+			<xsl:choose>
+				<xsl:when test="count(types/type[substring-before(.,'-models-') = 'f288']) = 1">
+
+					<xsl:variable name="no-args-model">
+						<xsl:value-of select="substring-after(substring-before(types/type[substring-before(.,'-models-') = 'f288'], '|'), '-models-')" />
+					</xsl:variable>
+
+					<xsl:variable name="args-model">
+						<xsl:value-of select="substring-after(types/type[substring-before(.,'-models-') = 'f288'], '|')" />
+					</xsl:variable>
+
+					<xsl:call-template name="framework-288-render-page">
+						<xsl:with-param name="handle" select="$handle" />
+						<xsl:with-param name="routes" select="$routes" />
+						<xsl:with-param name="model" select="$no-args-model" />
+					</xsl:call-template>
+
+					<xsl:call-template name="framework-288-render-page">
+						<xsl:with-param name="handle" select="concat($handle, '-detail')" />
+						<xsl:with-param name="routes" select="$routes" />
+						<xsl:with-param name="routes">
+							<xsl:call-template name="framework-288-page-routes">
+								<xsl:with-param name="item" select="$item" />
+								<xsl:with-param name="forceAllowArgs" select="true()" />
+							</xsl:call-template>
+						</xsl:with-param>
+						<xsl:with-param name="model" select="$args-model" />
+					</xsl:call-template>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:call-template name="framework-288-render-page">
+						<xsl:with-param name="handle" select="$handle" />
+						<xsl:with-param name="routes" select="$routes" />
+						<xsl:with-param name="model" select="$model" />
+					</xsl:call-template>
+				</xsl:otherwise>
+			</xsl:choose>
+
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template name="framework-288-page-routes">
+		<xsl:param name="item" />
+		<xsl:param name="forceAllowArgs" select="false()" />
+
 		<xsl:text>[</xsl:text>
 			<xsl:choose>
 				<xsl:when test="$is-multilingual">
@@ -67,6 +125,7 @@
 					<xsl:for-each select="/data/fl-languages/supported-languages/item [@main = 'yes']">
 						<xsl:call-template name="framework-288-url-creator-page-route">
 							<xsl:with-param name="item" select="$item" />
+							<xsl:with-param name="forceAllowArgs" select="$forceAllowArgs" />
 						</xsl:call-template>
 					</xsl:for-each>
 					
@@ -76,127 +135,115 @@
 						
 						<xsl:call-template name="framework-288-url-creator-page-route">
 							<xsl:with-param name="item" select="$item" />
+							<xsl:with-param name="forceAllowArgs" select="$forceAllowArgs" />
 						</xsl:call-template>
 					</xsl:for-each>
 					
 					<!-- Index page -->
-					<xsl:if test="@id = '1'">
+					<xsl:if test="@id = '1' and $forceAllowArgs = false()">
 						<xsl:text>,'/'</xsl:text>
 					</xsl:if>
 				</xsl:when>
 				<xsl:otherwise>
 					<xsl:call-template name="framework-288-url-creator-page-route">
 						<xsl:with-param name="item" select="$item" />
+						<xsl:with-param name="forceAllowArgs" select="$forceAllowArgs" />
 					</xsl:call-template>
 				</xsl:otherwise>
 			</xsl:choose>
 		<xsl:text>]</xsl:text>
-	</xsl:variable>
-	
-	<xsl:variable name="model">
-		<xsl:call-template name="framework-288-page-model">
-			<xsl:with-param name="types" select="types/type" />
-		</xsl:call-template>
-	</xsl:variable>
-	
-	<xsl:if test="count(types/type[. = 'f288-hidden']) = 0 and count(types/type[. = 'hidden']) = 0 and (count(types/type[. = 'admin']) = 0 or $is-logged-in = true())">
-		<xsl:call-template name="framework-288-render-page">
-			<xsl:with-param name="handle" select="$handle" />
-			<xsl:with-param name="routes" select="$routes" />
-			<xsl:with-param name="model" select="$model" />
-		</xsl:call-template>
-	</xsl:if>
-</xsl:template>
+	</xsl:template> <!-- framework-288-page-routes -->
 
-<xsl:template name="framework-288-url-creator-page-route">
-	<xsl:param name="item" />
-	
-	<xsl:variable name="allowArgs">
-		<xsl:choose>
-			<xsl:when test="count($item/types/type [. = $allowArgsName]) &gt; 0">
-				<xsl:text>yes</xsl:text>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:text>no</xsl:text>
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:variable>
-	
-	<xsl:variable name="isIndex">
-		<xsl:choose>
-			<xsl:when test="count($item/types/type [. = 'index']) &gt; 0">
-				<xsl:text>yes</xsl:text>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:text>no</xsl:text>
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:variable>
-	
-	<!-- Langue -->
-	<xsl:variable name="lg" select="@handle" />
-	<xsl:text>'/</xsl:text>
-	<xsl:if test="$is-multilingual">
-		<xsl:value-of select="$lg" />
-		<xsl:text>/</xsl:text>
-	</xsl:if>
-	
-	<!-- parents -->
-	<xsl:for-each select="$item/ancestor::page">
-		<xsl:choose>
-			<xsl:when test="$is-multilingual">
-				<xsl:value-of select="item [@lang=$lg]/@handle" />
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="@handle" />
-			</xsl:otherwise>
-		</xsl:choose>
-		<xsl:text>/</xsl:text>
-	</xsl:for-each>
-	
-	<!-- Current (if not index)-->
-	<xsl:if test="$isIndex != 'yes'">
-		<xsl:choose>
-			<xsl:when test="$is-multilingual">
-				<xsl:value-of select="$item/item [@lang=$lg]/@handle" />
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="@handle" />
-			</xsl:otherwise>
-		</xsl:choose>
-		<xsl:text>/</xsl:text>
-	</xsl:if>
-	
-	<!-- stars-->
-	<xsl:if test="$allowArgs = 'yes'">
-		<xsl:text>*</xsl:text>
-	</xsl:if>
-	<xsl:text>'</xsl:text>
-</xsl:template>
+	<xsl:template name="framework-288-url-creator-page-route">
+		<xsl:param name="item" />
+		<xsl:param name="forceAllowArgs" select="false()" />
+		
+		<xsl:variable name="allowArgs">
+			<xsl:choose>
+				<xsl:when test="count($item/types/type [. = $allowArgsName]) &gt; 0">
+					<xsl:text>yes</xsl:text>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:text>no</xsl:text>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+		
+		<xsl:variable name="isIndex">
+			<xsl:choose>
+				<xsl:when test="count($item/types/type [. = 'index']) &gt; 0">
+					<xsl:text>yes</xsl:text>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:text>no</xsl:text>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+		
+		<!-- Langue -->
+		<xsl:variable name="lg" select="@handle" />
+		<xsl:text>'/</xsl:text>
+		<xsl:if test="$is-multilingual">
+			<xsl:value-of select="$lg" />
+			<xsl:text>/</xsl:text>
+		</xsl:if>
+		
+		<!-- parents -->
+		<xsl:for-each select="$item/ancestor::page">
+			<xsl:choose>
+				<xsl:when test="$is-multilingual">
+					<xsl:value-of select="item [@lang=$lg]/@handle" />
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:value-of select="@handle" />
+				</xsl:otherwise>
+			</xsl:choose>
+			<xsl:text>/</xsl:text>
+		</xsl:for-each>
+		
+		<!-- Current (if not index)-->
+		<xsl:if test="$isIndex != 'yes'">
+			<xsl:choose>
+				<xsl:when test="$is-multilingual">
+					<xsl:value-of select="$item/item [@lang=$lg]/@handle" />
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:value-of select="@handle" />
+				</xsl:otherwise>
+			</xsl:choose>
+			<xsl:text>/</xsl:text>
+		</xsl:if>
+		
+		<!-- stars-->
+		<xsl:if test="$allowArgs = 'yes' or $forceAllowArgs">
+			<xsl:text>*</xsl:text>
+		</xsl:if>
+		<xsl:text>'</xsl:text>
+	</xsl:template>
 
-<xsl:template name="framework-288-page-model">
-	<xsl:param name="types" />
-	<xsl:choose>
-		<xsl:when test="count(exsl:node-set($types)[substring-before(.,'-model-') = 'f288']) &gt; 0">
-			<xsl:value-of select="substring-after(exsl:node-set($types)[string-length(substring-after(.,'f288-model-')) &gt; 0],'f288-model-')" />
-		</xsl:when>
-		<xsl:otherwise>
-			<xsl:text>default-page</xsl:text>
-		</xsl:otherwise>
-	</xsl:choose>
-</xsl:template>
+	<xsl:template name="framework-288-page-model">
+		<xsl:param name="types" />
+		<xsl:choose>
+			<xsl:when test="count(exsl:node-set($types)[substring-before(.,'-model-') = 'f288']) &gt; 0">
+				<xsl:value-of select="substring-after(exsl:node-set($types)[string-length(substring-after(.,'f288-model-')) &gt; 0],'f288-model-')" />
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:text>default-page</xsl:text>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
 
-<xsl:template name="framework-288-render-page">
-	<xsl:param name="handle" />
-	<xsl:param name="routes" select="concat('[&quot;', $current-path, '/&quot;]')" />
-	<xsl:param name="model" select="'default-page'" />
-	
-	<xsl:text>App.pages.create({key: '#page-</xsl:text>
-	<xsl:value-of select="$handle" />
-	<xsl:text>',routes: </xsl:text>
-	<xsl:value-of select="$routes" />
-	<xsl:text>},'</xsl:text>
-	<xsl:value-of select="$model" />
-	<xsl:text>');</xsl:text>
-</xsl:template>
+	<xsl:template name="framework-288-render-page">
+		<xsl:param name="handle" />
+		<xsl:param name="routes" select="concat('[&quot;', $current-path, '/&quot;]')" />
+		<xsl:param name="model" select="'default-page'" />
+		
+		<xsl:text>App.pages.create({key: '#page-</xsl:text>
+		<xsl:value-of select="$handle" />
+		<xsl:text>',routes: </xsl:text>
+		<xsl:value-of select="$routes" />
+		<xsl:text>},'</xsl:text>
+		<xsl:value-of select="$model" />
+		<xsl:text>');</xsl:text>
+	</xsl:template>
 </xsl:stylesheet>

--- a/workspace/utilities/site-variables.xsl
+++ b/workspace/utilities/site-variables.xsl
@@ -66,6 +66,9 @@
 	<xsl:call-template name="create-page-handle-by-id">
 		<xsl:with-param name="id" select="$current-page-id" />
 	</xsl:call-template>
+	<xsl:if test="count(/data/params/page-types/item[substring-before(.,'-models-') = 'f288']) &gt; 0">
+		<xsl:if test="string-length(/data/params/handle) != 0"><xsl:text>-detail</xsl:text></xsl:if>
+	</xsl:if>
 </xsl:variable>
 
 <!-- Decimal format: french -->


### PR DESCRIPTION
Syntax: `f288-models-foo-foo-foo|bar-bar-bar`

Where the first route generated will be `foo-foo-foo` 

and the second route will be `bar-bar-bar` (with f288-allowArgs forced on this route).

It's a cheap way to fix our _detail page_ problem with 2 articleChangers.