### PR TITLE
Font display

### DIFF
--- a/workspace/assets/css/core/fct-fonts.less
+++ b/workspace/assets/css/core/fct-fonts.less
@@ -1,6 +1,6 @@
 // FONTS FUNCTIONS
 // ref: http://www.paulirish.com/2009/bulletproof-font-face-implementation-syntax/
-#font-face (@font-family, @font-filename: @font-family, @font-weight:normal, @font-style: normal, @font-display: swap) {
+#font-face (@font-family, @font-filename: @font-family, @font-weight:normal, @font-style: normal, @font-display: fallback) {
 	font-family: @font-family;
 	src: local('?'),
 		url("@{font-path}@{font-filename}.woff2") format('woff2'),

--- a/workspace/assets/css/core/fct-fonts.less
+++ b/workspace/assets/css/core/fct-fonts.less
@@ -1,10 +1,11 @@
 // FONTS FUNCTIONS
 // ref: http://www.paulirish.com/2009/bulletproof-font-face-implementation-syntax/
-#font-face (@font-family, @font-filename: @font-family, @font-weight:normal, @font-style: normal) {
+#font-face (@font-family, @font-filename: @font-family, @font-weight:normal, @font-style: normal, @font-display: swap) {
 	font-family: @font-family;
 	src: local('?'),
 		url("@{font-path}@{font-filename}.woff2") format('woff2'),
 		url("@{font-path}@{font-filename}.woff") format('woff');
 	font-weight: @font-weight;
 	font-style: @font-style;
+	font-display: @font-display;
 }


### PR DESCRIPTION
Added the font-display CSS property with `swap` as a default value.

What it does is rendering all text with a system font while the real fonts are loading. This gives us the illusion of a website a little more faster because of this feature.

Of course, it's overridable if this effect is not desired, but who would spit on speed? 🤷‍♂ 

More info: https://css-tricks.com/font-display-masses/