### PR TITLE
(chore) Tidy up xsltimportextractor

### DIFF
--- a/workspace/assets/Gruntfile.js
+++ b/workspace/assets/Gruntfile.js
@@ -8,7 +8,6 @@ module.exports = function (grunt) {
 	var GRUNT_FILE = 'Gruntfile.js';
 	var BUILD_FILE = 'build.json';
 	var LESS_FILE = 'css/dev/grunt.less';
-	var PAGES_PATH = '../pages/*.xsl';
 	var DEV_LIB_BUNDLE_LESS_FILE = 'css/dev/lib.less';
 	var DEV_LIB_BUNDLE_LESS_FILE_PROD = 'css/dev/lib-prod.less';
 	var DEV_THEME_BUNDLE_LESS_FILE = 'css/dev/theme.less';
@@ -107,12 +106,6 @@ module.exports = function (grunt) {
 		watch: {
 			files: SRC_FILES.concat(GRUNT_FILE),
 			tasks: ['dev', 'css']
-		},
-
-		xsltimportextractor: {
-			options: {
-				pagesPath: PAGES_PATH
-			}
 		},
 
 		cssopruner: {

--- a/workspace/assets/tasks/xsltimportextractor.js
+++ b/workspace/assets/tasks/xsltimportextractor.js
@@ -2,8 +2,16 @@
 
 module.exports = function xsltimportextractor (grunt) {
 	// Set default config
-	
-	grunt.registerTask('xsltimportextractor', 'DESCRIPTION', function () {
+	grunt.config.merge({
+		xsltimportextractor: {
+			options: {
+				pagesPath: '../pages/*.xsl',
+				allowFilesNotFound: true
+			}
+		}
+	});
+
+	grunt.registerTask('xsltimportextractor', 'Builds a list of all used xslt files', function () {
 		var options = this.options();
 		var libxmljs = require('libxmljs');
 		var pages = grunt.file.expand(options.pagesPath);
@@ -45,24 +53,24 @@ module.exports = function xsltimportextractor (grunt) {
 						});
 
 						//Truncate a part
-						var splitedBasePath = basePath.split('/');
+						var splittedBasePath = basePath.split('/');
 
-						if (splitedBasePath.length > 1) {
+						if (splittedBasePath.length > 1) {
 							var newBasePath = '';
 							var x = 1;
 
-							splitedBasePath.forEach(function (item) {
+							splittedBasePath.forEach(function (item) {
 								if (x == 1) {
 									//always keep first ../
 									newBasePath += item + '/';
 									x += 1;
-								} else if (splitedBasePath.length - x > countRemove) {
+								} else if (splittedBasePath.length - x > countRemove) {
 									newBasePath += item + '/';
 									x += 1;
 								}
 							});
 
-							//Fix ../ if not enought
+							//Fix ../ if not enough
 							while (x < countRemove) {
 								newBasePath += '../';
 								x += 1;
@@ -74,9 +82,7 @@ module.exports = function xsltimportextractor (grunt) {
 						basePath += f.substring(0, lastSlash + 1);
 					}
 
-				} //else {
-				//Do nothing
-				//}
+				}
 
 				var fixedFilePath = basePath + f.substring(lastSlash + 1);
 
@@ -96,7 +102,10 @@ module.exports = function xsltimportextractor (grunt) {
 							imports.forEach(processImports);
 						}
 					} else {
-						grunt.log.writeln('xsltimportextractor: File not found: ' + fixedFilePath);
+						(options.allowFilesNotFound ?
+							grunt.verbose.writeln :
+							grunt.fail.fatal
+						)('Error: File not found: ' + fixedFilePath);
 					}
 					
 					level -= 1;


### PR DESCRIPTION
- Remove shared options from Gruntfile.js (always prefer the task file,
if the value is not shared)
- Fix a couple of typos
- Make it possible to fail when a file is not found
- Hide the error message in verbose mode only