### PR TITLE
Added dev task in build

### DIFF
--- a/workspace/assets/Gruntfile.js
+++ b/workspace/assets/Gruntfile.js
@@ -188,13 +188,13 @@ module.exports = function (grunt) {
 			'css-dev'
 		]);
 		grunt.registerTask('build', [
+			'dev',
 			'clean:bundleLess',
 			'concat:lessCore',
 			'concat:lessLib',
 			'xmlbundle:site',
 			'svninfo',
 			'buildnum',
-			'dev',
 			'js',
 			'css'
 		]);

--- a/workspace/assets/Gruntfile.js
+++ b/workspace/assets/Gruntfile.js
@@ -194,6 +194,7 @@ module.exports = function (grunt) {
 			'xmlbundle:site',
 			'svninfo',
 			'buildnum',
+			'dev',
 			'js',
 			'css'
 		]);


### PR DESCRIPTION
Alright. I know it's a pain in the ass and it slows a bit the build process but here is my thinking about it.

- The dev task is not used enough.
- The builds are what is directly pushed into production and we always only run `grunt build push`.
- We need the best version we can make of our code in production.
- We should run `dev` to before doing a build so it can find errors and directly flag it.
- The rules imposed by our jshint directly improve the readability and therefore our maintability of these files.